### PR TITLE
Add tesco butter pricing

### DIFF
--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -93,7 +93,7 @@ sql_val = (
 
 dbcursor = database.cursor()
 dbcursor.execute(sql, sql_val)
-# database.commit()
+database.commit()
 
 print(dbcursor.rowcount, "record inserted.")
 print("%s: Unsalted Butter at Waitrose is £%s/kg" % (date_str, waitrose_unsalted_butter["price_per_kg"]))


### PR DESCRIPTION
Added function for Tesco unsalted butter price data scraping as well as the appropriate dict and code for MySQL database pushing.

Required the addition of changing the user-agent in the headers of the get-request for the URL becuase it seemed that it was detecting the script as a bot and blocking the connection. The headers have been added to the Waitrose butter get-request as well for safety.