### PR TITLE
Add Lidl butter pricing

### DIFF
--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -106,8 +106,11 @@ def get_lidl_unsalted_butter_price_per_kg():
     page = requests.get(lidl_unsalted_butter["url"])
     soup = BeautifulSoup(page.content, "html.parser")
 
-    price_per_100g = soup.find(class_="pricebox__basic-quantity")
-    price_per_kg = float(price_per_100g.text.strip()[6:][:-6:]) * 0.1
+    ### 2022-12-30 WARNING: Price per item and price per unit differ on webpage (assuming price per item is correct for now) ###
+    # price_per_100g = soup.find(class_="pricebox__basic-quantity")
+    # price_per_kg = float(price_per_100g.text.strip()[6:][:-6:]) * 0.1
+    price_per_item = soup.find("span", class_="pricebox__price")
+    price_per_kg = float(price_per_item.text.strip()[2:]) * 4 # std item weight = 250g
 
     return ("%.2f" % price_per_kg)
 

--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -39,6 +39,9 @@ aldi_unsalted_butter = {
 asda_unsalted_butter = {
     "url": 'https://groceries.asda.com/product/block-butter/asda-unsalted-butter/910000419159'
 }
+lidl_unsalted_butter = {
+    "url": 'https://www.lidl.co.uk/p/aberdoyle-dairies/aberdoyle-dairies-scottish-unsalted-butter/p16722'
+}
 
 def get_waitrose_unsalted_butter_price_per_kg():
     page = requests.get(waitrose_unsalted_butter["url"], headers=request_headers)

--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -102,11 +102,21 @@ def get_asda_unsalted_butter_price_per_kg():
 
     return price_per_kg.text[2:][:-4:]
 
+def get_lidl_unsalted_butter_price_per_kg():
+    page = requests.get(lidl_unsalted_butter["url"])
+    soup = BeautifulSoup(page.content, "html.parser")
+
+    price_per_100g = soup.find(class_="pricebox__basic-quantity")
+    price_per_kg = float(price_per_100g.text.strip()[6:][:-6:]) * 0.1
+
+    return ("%.2f" % price_per_kg)
+
 waitrose_unsalted_butter["price_per_kg"] = get_waitrose_unsalted_butter_price_per_kg()
 tesco_unsalted_butter["price_per_kg"] = get_tesco_unsalted_butter_price_per_kg()
 sainsburys_unsalted_butter["price_per_kg"] = get_sainsburys_unsalted_butter_price_per_kg()
 aldi_unsalted_butter["price_per_kg"] = get_aldi_unsalted_butter_price_per_kg()
 asda_unsalted_butter["price_per_kg"] = get_asda_unsalted_butter_price_per_kg()
+lidl_unsalted_butter["price_per_kg"] = get_lidl_unsalted_butter_price_per_kg()
 
 now = datetime.datetime.now()
 date_str = str(now.date())

--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -148,4 +148,5 @@ print("%s: Unsalted Butter at Tesco is £%s/kg" % (date_str, tesco_unsalted_butt
 print("%s: Unsalted Butter at Sainsbury's is £%s/kg" % (date_str, sainsburys_unsalted_butter["price_per_kg"]))
 print("%s: Unsalted Butter at Aldi is £%s/kg" % (date_str, aldi_unsalted_butter["price_per_kg"]))
 print("%s: Unsalted Butter at ASDA is £%s/kg" % (date_str, asda_unsalted_butter["price_per_kg"]))
+print("%s: Unsalted Butter at Lidl is £%s/kg" % (date_str, lidl_unsalted_butter["price_per_kg"]))
 time.sleep(5)

--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -131,19 +131,20 @@ database = mysql.connector.connect(
     database="grocery_prices"
 )
 
-sql = "INSERT INTO unsalted_butter_price_per_kg (Date, Waitrose, Tesco, Sainsburys, Aldi, ASDA) VALUES (%s, %s, %s, %s, %s, %s)"
+sql = "INSERT INTO unsalted_butter_price_per_kg (Date, Waitrose, Tesco, Sainsburys, Aldi, ASDA, Lidl) VALUES (%s, %s, %s, %s, %s, %s, %s)"
 sql_val = (
     date_str,
     waitrose_unsalted_butter["price_per_kg"],
     tesco_unsalted_butter["price_per_kg"],
     sainsburys_unsalted_butter["price_per_kg"],
     aldi_unsalted_butter["price_per_kg"],
-    asda_unsalted_butter["price_per_kg"]
+    asda_unsalted_butter["price_per_kg"],
+    lidl_unsalted_butter["price_per_kg"]
     )
 
 dbcursor = database.cursor()
-# dbcursor.execute(sql, sql_val)
-# database.commit()
+dbcursor.execute(sql, sql_val)
+database.commit()
 
 print(dbcursor.rowcount, "record inserted.")
 print("%s: Unsalted Butter at Waitrose is £%s/kg" % (date_str, waitrose_unsalted_butter["price_per_kg"]))

--- a/track-grocery-prices.py
+++ b/track-grocery-prices.py
@@ -129,8 +129,8 @@ sql_val = (
     )
 
 dbcursor = database.cursor()
-dbcursor.execute(sql, sql_val)
-database.commit()
+# dbcursor.execute(sql, sql_val)
+# database.commit()
 
 print(dbcursor.rowcount, "record inserted.")
 print("%s: Unsalted Butter at Waitrose is £%s/kg" % (date_str, waitrose_unsalted_butter["price_per_kg"]))


### PR DESCRIPTION
For some reason, on the Lidl website, the price per item and price per unit doesn't match:
![image](https://user-images.githubusercontent.com/56632002/210068552-19f05249-83af-4430-be86-c475bb3b2ae1.png)

Code for each scenario has been added, but assuming the price per item is the correct price for now (not the price per 100g, though this would be more ideal for calculation)

This webpage will need to be re-checked in the future to see if the problem is amended, so that the code can be changed.